### PR TITLE
fixed contact section with target = blank

### DIFF
--- a/events/templates/events/events.html
+++ b/events/templates/events/events.html
@@ -366,9 +366,9 @@
             </div>
             <div style="height: 1vh;"></div>
             <div class="text-center">
-              <a href=" https://www.facebook.com/mlsctiet/"><img src="{% static 'events/Events/fb.png' %}" alt="Facebook" class="contact_link"></a> 
-              <a href="https://github.com/MicrosoftStudentChapter"><img src="{% static 'events/Events/github-04.png' %}" alt="Twitter" class="contact_link"></a>
-              <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h"><img src="{% static 'events/Events/insta.png' %}" alt="Instagram" class="contact_link"></a>
+              <a href=" https://www.facebook.com/mlsctiet/" target="_blank"><img src="{% static 'events/Events/fb.png' %}" alt="Facebook" class="contact_link"></a> 
+              <a href="https://github.com/MicrosoftStudentChapter" target="_blank"><img src="{% static 'events/Events/github-04.png' %}" alt="Twitter" class="contact_link"></a>
+              <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h" target="_blank"><img src="{% static 'events/Events/insta.png' %}" alt="Instagram" class="contact_link"></a>
             </div>
             <div style="height: 2vh;"></div>
           </div>

--- a/gallery/templates/gallery/gallery.html
+++ b/gallery/templates/gallery/gallery.html
@@ -205,9 +205,9 @@
           </div>
           <div style="height: 1vh;"></div>
           <div class="text-center">
-            <a href=" https://www.facebook.com/mlsctiet/"><img src="{% static 'gallery/pics/general/fb.png' %}" alt="Facebook" class="contact_link"></a> 
-            <a href="https://github.com/MicrosoftStudentChapter"><img src="{% static 'gallery/pics/general/github-04.png' %}" alt="Twitter" class="contact_link"></a>
-            <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h"><img src="{% static 'gallery/pics/general/insta.png' %}" alt="Instagram" class="contact_link"></a>
+            <a href=" https://www.facebook.com/mlsctiet/" target="_blank"><img src="{% static 'gallery/pics/general/fb.png' %}" alt="Facebook" class="contact_link"></a> 
+            <a href="https://github.com/MicrosoftStudentChapter" target="_blank"><img src="{% static 'gallery/pics/general/github-04.png' %}" alt="Twitter" class="contact_link"></a>
+            <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h" target="_blank"><img src="{% static 'gallery/pics/general/insta.png' %}" alt="Instagram" class="contact_link"></a>
           </div>
           <div style="height: 2vh;"></div>
         </div>

--- a/main/templates/main/home.html
+++ b/main/templates/main/home.html
@@ -255,9 +255,9 @@
         </div>
         <div style="height: 1vh;"></div>
         <div class="text-center">
-          <a href=" https://www.facebook.com/mlsctiet/"><img src="{% static 'main/pics/ContactUs/fb.png' %}" alt="Facebook" class="contact_link"></a> 
-          <a href="https://github.com/MicrosoftStudentChapter"><img src="{% static 'main/pics/ContactUs/github-04.png' %}" alt="Twitter" class="contact_link"></a>
-          <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h"><img src="{% static 'main/pics/ContactUs/insta.png' %}" alt="Instagram" class="contact_link"></a>
+          <a href=" https://www.facebook.com/mlsctiet/" target="_blank"><img src="{% static 'main/pics/ContactUs/fb.png' %}" alt="Facebook" class="contact_link"></a> 
+          <a href="https://github.com/MicrosoftStudentChapter" target="_blank"><img src="{% static 'main/pics/ContactUs/github-04.png' %}" alt="Twitter" class="contact_link"></a>
+          <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h" target="_blank"><img src="{% static 'main/pics/ContactUs/insta.png' %}" alt="Instagram" class="contact_link"></a>
         </div>
         <div style="height: 2vh;"></div>
       </div>

--- a/members/templates/members/about.html
+++ b/members/templates/members/about.html
@@ -1369,19 +1369,19 @@
         </div>
         <div style="height: 1vh"></div>
         <div class="text-center">
-          <a href=" https://www.facebook.com/mlsctiet/"
+          <a href=" https://www.facebook.com/mlsctiet/" target="_blank"
             ><img
               src="{% static 'members/general/fb.png' %}"
               alt="Facebook"
               class="contact_link"
           /></a>
-          <a href="https://github.com/MicrosoftStudentChapter"
+          <a href="https://github.com/MicrosoftStudentChapter" target="_blank"
             ><img
               src="{% static 'members/general/github-04.png' %}"
               alt="Twitter"
               class="contact_link"
           /></a>
-          <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h"
+          <a href="https://instagram.com/mlsc_tiet?igshid=bbv9mjjkx4h" target="_blank"
             ><img
               src="{% static 'members/general/insta.png' %}"
               alt="Instagram"


### PR DESCRIPTION
on instagram, github and facebook logo in the contact us section, added target="_blank" so that the links open in new window.